### PR TITLE
feat(task): add parent task support

### DIFF
--- a/packages/core/lib/data/datasources/db/database_helper.dart
+++ b/packages/core/lib/data/datasources/db/database_helper.dart
@@ -300,6 +300,7 @@ class DatabaseHelper {
         T.due_date,
         T.priority,
         T.description,
+        T.parent_task_id,
         T.project_id,
         P.name as project_name
       FROM tasks T
@@ -320,7 +321,7 @@ class DatabaseHelper {
       _tblTasks,
       where: 'project_id = ?',
       whereArgs: [projectId],
-      orderBy: 'order_sequence ASC',
+      orderBy: 'parent_task_id ASC, order_sequence ASC',
     );
   }
 

--- a/packages/task/lib/data/models/task_table.dart
+++ b/packages/task/lib/data/models/task_table.dart
@@ -9,6 +9,7 @@ class TaskTable extends Equatable {
   final int? dueDate;
   final int priority;
   final String? description;
+  final int? parentTaskId;
 
   const TaskTable({
     required this.id,
@@ -18,6 +19,7 @@ class TaskTable extends Equatable {
     this.dueDate,
     this.priority = 0,
     this.description,
+    this.parentTaskId,
   });
 
   factory TaskTable.fromMap(Map<String, dynamic> map) => TaskTable(
@@ -28,6 +30,7 @@ class TaskTable extends Equatable {
     dueDate: map['due_date'],
     priority: map['priority'] ?? 0,
     description: map['description'],
+    parentTaskId: map['parent_task_id'],
   );
 
   Map<String, dynamic> toJson() => {
@@ -37,6 +40,7 @@ class TaskTable extends Equatable {
     'due_date': dueDate,
     'priority': priority,
     'description': description,
+    'parent_task_id': parentTaskId,
   };
 
   factory TaskTable.fromEntity(Task task) => TaskTable(
@@ -47,6 +51,7 @@ class TaskTable extends Equatable {
     dueDate: task.dueDate,
     priority: task.priority,
     description: task.description,
+    parentTaskId: task.parentTaskId,
   );
 
   Task toEntity() => Task(
@@ -57,6 +62,7 @@ class TaskTable extends Equatable {
     dueDate: dueDate,
     priority: priority,
     description: description,
+    parentTaskId: parentTaskId,
   );
 
   @override
@@ -68,5 +74,6 @@ class TaskTable extends Equatable {
     dueDate,
     priority,
     description,
+    parentTaskId,
   ];
 }

--- a/packages/task/lib/data/models/task_with_project_info_table.dart
+++ b/packages/task/lib/data/models/task_with_project_info_table.dart
@@ -10,6 +10,7 @@ class TaskWithProjectInfoTable extends Equatable {
   final int? dueDate;
   final int priority;
   final String? description;
+  final int? parentTaskId;
   final int projectId;
   final String projectName;
 
@@ -21,6 +22,7 @@ class TaskWithProjectInfoTable extends Equatable {
     this.dueDate,
     this.priority = 0,
     this.description,
+    this.parentTaskId,
     required this.projectId,
     required this.projectName,
   });
@@ -34,6 +36,7 @@ class TaskWithProjectInfoTable extends Equatable {
       dueDate: map['due_date'],
       priority: map['priority'] ?? 0,
       description: map['description'],
+      parentTaskId: map['parent_task_id'],
       projectId: map['project_id'],
       projectName: map['project_name'],
     );
@@ -50,6 +53,7 @@ class TaskWithProjectInfoTable extends Equatable {
         dueDate: dueDate,
         priority: priority,
         description: description,
+        parentTaskId: parentTaskId,
       ),
       projectName: projectName,
     );
@@ -64,6 +68,7 @@ class TaskWithProjectInfoTable extends Equatable {
     dueDate,
     priority,
     description,
+    parentTaskId,
     projectId,
     projectName,
   ];

--- a/packages/task/lib/domain/entities/task.dart
+++ b/packages/task/lib/domain/entities/task.dart
@@ -8,6 +8,7 @@ class Task extends Equatable {
   final int? dueDate;
   final int priority;
   final String? description;
+  final int? parentTaskId;
 
   const Task({
     required this.id,
@@ -17,6 +18,7 @@ class Task extends Equatable {
     this.dueDate,
     this.priority = 0,
     this.description,
+    this.parentTaskId,
   });
 
   @override
@@ -28,5 +30,6 @@ class Task extends Equatable {
     dueDate,
     priority,
     description,
+    parentTaskId,
   ];
 }

--- a/packages/task/lib/presentation/bloc/create_task/create_task_bloc.dart
+++ b/packages/task/lib/presentation/bloc/create_task/create_task_bloc.dart
@@ -22,12 +22,14 @@ class CreateTaskBloc extends Bloc<CreateTaskEvent, CreateTaskState> {
 
       resultTasks.fold(
         (failure) {
-          // Bisa default ke 1 kalau gagal ambil
           newOrder = 1;
         },
         (tasks) {
-          if (tasks.isNotEmpty) {
-            final maxOrder = tasks
+          final siblings = tasks
+              .where((t) => t.parentTaskId == event.parentTaskId)
+              .toList();
+          if (siblings.isNotEmpty) {
+            final maxOrder = siblings
                 .map((t) => t.orderSequence)
                 .reduce((a, b) => a > b ? a : b);
             newOrder = maxOrder + 1;
@@ -43,6 +45,7 @@ class CreateTaskBloc extends Bloc<CreateTaskEvent, CreateTaskState> {
         dueDate: event.dueDate,
         priority: event.priority,
         description: event.description,
+        parentTaskId: event.parentTaskId,
       );
 
       final result = await _saveTask(projectId: event.projectId, task: newTask);

--- a/packages/task/lib/presentation/bloc/create_task/create_task_event.dart
+++ b/packages/task/lib/presentation/bloc/create_task/create_task_event.dart
@@ -13,6 +13,7 @@ class TaskSubmitted extends CreateTaskEvent {
   final String? description;
   final int? dueDate;
   final int priority;
+  final int? parentTaskId;
 
   const TaskSubmitted({
     required this.projectId,
@@ -20,5 +21,6 @@ class TaskSubmitted extends CreateTaskEvent {
     this.description,
     this.dueDate,
     this.priority = 0,
+    this.parentTaskId,
   });
 }

--- a/packages/task/pubspec.yaml
+++ b/packages/task/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   equatable: ^2.0.7
   dartz: ^0.10.1
   flutter_bloc: ^9.1.1
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- support nested tasks by adding optional `parentTaskId` to task models
- persist parent-child relationships in local data source and database queries
- show tasks hierarchically with expandable lists in the task page
