### PR TITLE
feat: add analytics charts for dashboard

### DIFF
--- a/lib/injection.dart
+++ b/lib/injection.dart
@@ -54,6 +54,7 @@ import 'package:task/presentation/bloc/update_tasks_order/update_tasks_order_blo
 import 'package:task/domain/usecases/search_tasks.dart';
 import 'package:task/presentation/bloc/search_tasks/search_tasks_bloc.dart';
 import 'package:core/notification_service.dart';
+import 'package:core/analytics/analytics_service.dart';
 
 final locator = GetIt.instance;
 
@@ -167,7 +168,10 @@ Future<void> init() async {
   // Repository
   // Project
   locator.registerLazySingleton<ProjectRepository>(
-    () => ProjectRepositoryImpl(localDataSource: locator()),
+    () => ProjectRepositoryImpl(
+      localDataSource: locator(),
+      analyticsService: locator(),
+    ),
   );
   // task
   locator.registerLazySingleton<TaskRepository>(
@@ -199,5 +203,8 @@ Future<void> init() async {
   locator.registerLazySingleton<DatabaseHelper>(() => DatabaseHelper());
   locator.registerLazySingleton<NotificationService>(
     () => NotificationService(),
+  );
+  locator.registerLazySingleton<AnalyticsService>(
+    () => const AnalyticsService(),
   );
 }

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -7,9 +7,11 @@ import 'package:project/presentation/bloc/get_project_items/get_project_items_bl
 import 'package:project_box/presentation/widgets/banner_images.dart';
 import 'package:project_box/presentation/widgets/next_task_section.dart';
 import 'package:project_box/presentation/widgets/recent_projects.dart';
-  import 'package:project_box/presentation/widgets/stats_info_section.dart';
-  import 'package:project_box/presentation/widgets/task_completion_chart.dart';
-  import 'package:task/presentation/bloc/next_tasks/next_tasks_bloc.dart';
+import 'package:project_box/presentation/widgets/stats_info_section.dart';
+import 'package:project_box/presentation/widgets/task_completion_chart.dart';
+import 'package:project_box/presentation/widgets/burn_down_chart.dart';
+import 'package:project_box/presentation/widgets/velocity_chart.dart';
+import 'package:task/presentation/bloc/next_tasks/next_tasks_bloc.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:share_plus/share_plus.dart';
 import 'dart:io';
@@ -97,23 +99,23 @@ class HomePageState extends State<HomePage> {
     return Scaffold(
       backgroundColor: Colors.grey[100],
       appBar: AppBar(
-          title: Text(l10n.appTitle),
+        title: Text(l10n.appTitle),
         actions: [
-            IconButton(
-              icon: const Icon(Icons.upload_file),
-              tooltip: l10n.export,
-              onPressed: _exportData,
-            ),
-            IconButton(
-              icon: const Icon(Icons.download),
-              tooltip: l10n.import,
-              onPressed: _importData,
-            ),
-            IconButton(
-              icon: const Icon(Icons.settings),
-              tooltip: l10n.settings,
-              onPressed: () => context.push('/settings'),
-            ),
+          IconButton(
+            icon: const Icon(Icons.upload_file),
+            tooltip: l10n.export,
+            onPressed: _exportData,
+          ),
+          IconButton(
+            icon: const Icon(Icons.download),
+            tooltip: l10n.import,
+            onPressed: _importData,
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: l10n.settings,
+            onPressed: () => context.push('/settings'),
+          ),
         ],
       ),
       body: SafeArea(
@@ -125,6 +127,10 @@ class HomePageState extends State<HomePage> {
             const StatsInfoSection(),
             const SizedBox(height: 16),
             const TaskCompletionChart(),
+            const SizedBox(height: 16),
+            const BurnDownChart(),
+            const SizedBox(height: 16),
+            const VelocityChart(),
             const SizedBox(height: 16),
             NextTaskSection(),
             const SizedBox(height: 16),

--- a/lib/presentation/widgets/burn_down_chart.dart
+++ b/lib/presentation/widgets/burn_down_chart.dart
@@ -1,0 +1,101 @@
+import 'package:core/common/state_enum.dart';
+import 'package:core/l10n/app_localizations.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:project/presentation/bloc/dashboard_stats/dashboard_stats_bloc.dart';
+
+class BurnDownChart extends StatelessWidget {
+  const BurnDownChart({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2.0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: SizedBox(
+          height: 200,
+          child: BlocBuilder<DashboardStatsBloc, DashboardStatsState>(
+            builder: (context, state) {
+              switch (state.state) {
+                case RequestState.loading:
+                  return const Center(child: CircularProgressIndicator());
+                case RequestState.error:
+                  return Center(child: Text(state.message));
+                case RequestState.loaded:
+                  final stats = state.stats;
+                  final data = stats?.burnDownData ?? [];
+                  if (data.isEmpty) {
+                    return Center(
+                      child: Text(AppLocalizations.of(context)!.noData),
+                    );
+                  }
+                  final now = DateTime.now();
+                  final labels = List.generate(data.length, (index) {
+                    final date = now.subtract(
+                      Duration(days: data.length - 1 - index),
+                    );
+                    return DateFormat('E').format(date);
+                  });
+                  final spots = List.generate(
+                    data.length,
+                    (index) => FlSpot(index.toDouble(), data[index].toDouble()),
+                  );
+                  return LineChart(
+                    LineChartData(
+                      gridData: const FlGridData(show: false),
+                      borderData: FlBorderData(show: false),
+                      titlesData: FlTitlesData(
+                        leftTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: true),
+                        ),
+                        rightTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        topTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        bottomTitles: AxisTitles(
+                          sideTitles: SideTitles(
+                            showTitles: true,
+                            reservedSize: 32,
+                            getTitlesWidget: (value, meta) {
+                              final index = value.toInt();
+                              if (index < 0 || index >= labels.length) {
+                                return const SizedBox.shrink();
+                              }
+                              return Padding(
+                                padding: const EdgeInsets.only(top: 4.0),
+                                child: Text(
+                                  labels[index],
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                      lineBarsData: [
+                        LineChartBarData(
+                          spots: spots,
+                          isCurved: true,
+                          color: Theme.of(context).colorScheme.primary,
+                          barWidth: 3,
+                          dotData: const FlDotData(show: false),
+                        ),
+                      ],
+                    ),
+                  );
+                default:
+                  return const SizedBox.shrink();
+              }
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/velocity_chart.dart
+++ b/lib/presentation/widgets/velocity_chart.dart
@@ -1,0 +1,112 @@
+import 'package:core/common/state_enum.dart';
+import 'package:core/l10n/app_localizations.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import 'package:project/presentation/bloc/dashboard_stats/dashboard_stats_bloc.dart';
+
+class VelocityChart extends StatelessWidget {
+  const VelocityChart({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2.0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.0)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: SizedBox(
+          height: 200,
+          child: BlocBuilder<DashboardStatsBloc, DashboardStatsState>(
+            builder: (context, state) {
+              switch (state.state) {
+                case RequestState.loading:
+                  return const Center(child: CircularProgressIndicator());
+                case RequestState.error:
+                  return Center(child: Text(state.message));
+                case RequestState.loaded:
+                  final stats = state.stats;
+                  final data = stats?.dailyTaskCompletions ?? [];
+                  if (data.isEmpty) {
+                    return Center(
+                      child: Text(AppLocalizations.of(context)!.noData),
+                    );
+                  }
+                  final now = DateTime.now();
+                  final labels = List.generate(data.length, (index) {
+                    final date = now.subtract(
+                      Duration(days: data.length - 1 - index),
+                    );
+                    return DateFormat('E').format(date);
+                  });
+                  final spots = List.generate(
+                    data.length,
+                    (index) => FlSpot(index.toDouble(), data[index].toDouble()),
+                  );
+                  final avg = stats?.velocity ?? 0;
+                  return LineChart(
+                    LineChartData(
+                      gridData: const FlGridData(show: false),
+                      borderData: FlBorderData(show: false),
+                      titlesData: FlTitlesData(
+                        leftTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: true),
+                        ),
+                        rightTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        topTitles: const AxisTitles(
+                          sideTitles: SideTitles(showTitles: false),
+                        ),
+                        bottomTitles: AxisTitles(
+                          sideTitles: SideTitles(
+                            showTitles: true,
+                            reservedSize: 32,
+                            getTitlesWidget: (value, meta) {
+                              final index = value.toInt();
+                              if (index < 0 || index >= labels.length) {
+                                return const SizedBox.shrink();
+                              }
+                              return Padding(
+                                padding: const EdgeInsets.only(top: 4.0),
+                                child: Text(
+                                  labels[index],
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                      lineBarsData: [
+                        LineChartBarData(
+                          spots: spots,
+                          isCurved: true,
+                          color: Theme.of(context).colorScheme.primary,
+                          barWidth: 3,
+                        ),
+                        LineChartBarData(
+                          spots: [
+                            FlSpot(0, avg),
+                            FlSpot((data.length - 1).toDouble(), avg),
+                          ],
+                          isCurved: false,
+                          color: Colors.grey,
+                          dashArray: [5, 5],
+                          barWidth: 2,
+                          dotData: const FlDotData(show: false),
+                        ),
+                      ],
+                    ),
+                  );
+                default:
+                  return const SizedBox.shrink();
+              }
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/core/lib/analytics/analytics_service.dart
+++ b/packages/core/lib/analytics/analytics_service.dart
@@ -1,0 +1,28 @@
+import 'dart:math';
+
+/// Provides simple analytics calculations for dashboard metrics.
+class AnalyticsService {
+  const AnalyticsService();
+
+  /// Calculate remaining tasks for a burn‑down chart.
+  ///
+  /// [totalTasks] is the current total number of tasks and
+  /// [dailyCompletions] are tasks completed for each day (oldest first).
+  /// Returns a list with the remaining tasks after each day.
+  List<int> calculateBurnDown(int totalTasks, List<int> dailyCompletions) {
+    final remaining = <int>[];
+    var current = totalTasks;
+    for (final completed in dailyCompletions) {
+      current = max(0, current - completed);
+      remaining.add(current);
+    }
+    return remaining;
+  }
+
+  /// Calculate average task completion velocity per day.
+  double calculateVelocity(List<int> dailyCompletions) {
+    if (dailyCompletions.isEmpty) return 0;
+    final total = dailyCompletions.fold<int>(0, (a, b) => a + b);
+    return total / dailyCompletions.length;
+  }
+}

--- a/packages/core/lib/data/datasources/db/database_helper.dart
+++ b/packages/core/lib/data/datasources/db/database_helper.dart
@@ -125,6 +125,9 @@ class DatabaseHelper {
     );
     final totalTasksDone = Sqflite.firstIntValue(totalTasksDoneResult) ?? 0;
 
+    final totalTasksResult = await db.rawQuery("SELECT COUNT(*) FROM tasks");
+    final totalTasks = Sqflite.firstIntValue(totalTasksResult) ?? 0;
+
     // Hitung jumlah tugas yang diselesaikan setiap hari untuk 7 hari terakhir
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
@@ -162,6 +165,7 @@ class DatabaseHelper {
       'totalTasksDone': totalTasksDone,
       'productiveStreak': productiveStreak,
       'dailyTaskCompletions': dailyTaskCompletions,
+      'totalTasks': totalTasks,
     };
   }
 

--- a/packages/project/lib/data/repositories/project_repository_impl.dart
+++ b/packages/project/lib/data/repositories/project_repository_impl.dart
@@ -7,11 +7,16 @@ import 'package:project/domain/repositories/project_repository.dart';
 import 'package:project/data/datasources/project_local_data_source.dart';
 import 'package:project/data/models/project_table.dart';
 import 'package:project/domain/enitites/project.dart';
+import 'package:core/analytics/analytics_service.dart';
 
 class ProjectRepositoryImpl implements ProjectRepository {
   final ProjectLocalDataSource localDataSource;
+  final AnalyticsService analyticsService;
 
-  ProjectRepositoryImpl({required this.localDataSource});
+  ProjectRepositoryImpl({
+    required this.localDataSource,
+    required this.analyticsService,
+  });
 
   @override
   Future<Either<Failure, List<Project>>> getProjects({int? limit}) async {
@@ -87,16 +92,20 @@ class ProjectRepositoryImpl implements ProjectRepository {
   Future<Either<Failure, DashboardStats>> getDashboardStats() async {
     try {
       final result = await localDataSource.getDashboardStats();
+      final daily = (result['dailyTaskCompletions'] as List<dynamic>? ?? [])
+          .cast<int>();
+      final totalTasks = result['totalTasks'] as int? ?? 0;
+      final burnDown = analyticsService.calculateBurnDown(totalTasks, daily);
+      final velocity = analyticsService.calculateVelocity(daily);
       // Ubah Map menjadi Entitas
       return Right(
         DashboardStats(
           completedProjects: result['completedProjects'] ?? 0,
           totalTasksDone: result['totalTasksDone'] ?? 0,
           productiveStreak: result['productiveStreak'] ?? 0,
-          dailyTaskCompletions:
-              (result['dailyTaskCompletions'] as List<dynamic>? ?? [])
-                  .map((e) => e as int)
-                  .toList(),
+          dailyTaskCompletions: daily,
+          burnDownData: burnDown,
+          velocity: velocity,
         ),
       );
     } on DatabaseException catch (e) {

--- a/packages/project/lib/domain/enitites/dashboard_stats.dart
+++ b/packages/project/lib/domain/enitites/dashboard_stats.dart
@@ -5,12 +5,16 @@ class DashboardStats extends Equatable {
   final int totalTasksDone;
   final int productiveStreak;
   final List<int> dailyTaskCompletions;
+  final List<int> burnDownData;
+  final double velocity;
 
   const DashboardStats({
     required this.completedProjects,
     required this.totalTasksDone,
     required this.productiveStreak,
     required this.dailyTaskCompletions,
+    required this.burnDownData,
+    required this.velocity,
   });
 
   @override
@@ -19,5 +23,7 @@ class DashboardStats extends Equatable {
     totalTasksDone,
     productiveStreak,
     dailyTaskCompletions,
+    burnDownData,
+    velocity,
   ];
 }


### PR DESCRIPTION
## Summary
- add analytics service to compute burn-down and velocity metrics
- show burn-down and velocity charts on home dashboard
- wire analytics into repository and injection for dashboard stats
